### PR TITLE
Handle \r\n and \r when splitting the custom brush directory string

### DIFF
--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -727,7 +727,7 @@ namespace BrushFactory
             value = (string)key.GetValue("customBrushLocations");
             if (value != null)
             {
-                customBrushDirectories = value.Split('\n');
+                customBrushDirectories = value.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries);
             }
 
             key.Close();


### PR DESCRIPTION
This fixes the issue welshblue reported with only the last folder in the list being loaded.

https://forums.getpaint.net/topic/113361-whats-next-for-brush-factory/?do=findComment&comment=550283