### PR TITLE
Remove the PresentationCore dependency

### DIFF
--- a/BrushFactory.csproj
+++ b/BrushFactory.csproj
@@ -92,7 +92,6 @@
       <HintPath>..\..\..\..\..\..\..\Program Files\paint.net\PaintDotNet.SystemLayer.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -108,6 +107,7 @@
       <DependentUpon>BrushFactoryPreferences.cs</DependentUpon>
     </Compile>
     <Compile Include="Gui\BrushSelectorItem.cs" />
+    <Compile Include="Interop\SafeNativeMethods.cs" />
     <Compile Include="InterpolationItem.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -2222,6 +2222,14 @@ namespace BrushFactory
         }
 
         /// <summary>
+        /// Determines whether the specified key is down.
+        /// </summary>
+        private static bool IsKeyDown(Keys key)
+        {
+            return Interop.SafeNativeMethods.GetKeyState((int)key) < 0;
+        }
+
+        /// <summary>
         /// Displays a context menu for changing background color options.
         /// </summary>
         /// <param name="sender">
@@ -2644,8 +2652,7 @@ namespace BrushFactory
             if (ModifierKeys == Keys.Control)
             {
                 //Ctrl + S + Wheel: Changes the brush size.
-                if (System.Windows.Input.Keyboard.IsKeyDown
-                    (System.Windows.Input.Key.S))
+                if (IsKeyDown(Keys.S))
                 {
                     int changeFactor = 10;
 
@@ -2677,8 +2684,7 @@ namespace BrushFactory
                 }
 
                 //Ctrl + R + Wheel: Changes the brush rotation.
-                else if (System.Windows.Input.Keyboard.IsKeyDown
-                    (System.Windows.Input.Key.R))
+                else if (IsKeyDown(Keys.R))
                 {
                     sliderBrushRotation.Value = Utils.Clamp(
                     sliderBrushRotation.Value + Math.Sign(e.Delta) * 20,
@@ -2687,8 +2693,7 @@ namespace BrushFactory
                 }
 
                 //Ctrl + A + Wheel: Changes the brush alpha.
-                else if (System.Windows.Input.Keyboard.IsKeyDown
-                    (System.Windows.Input.Key.A))
+                else if (IsKeyDown(Keys.A))
                 {
                     sliderBrushAlpha.Value = Utils.Clamp(
                     sliderBrushAlpha.Value + Math.Sign(e.Delta) * 10,

--- a/Interop/SafeNativeMethods.cs
+++ b/Interop/SafeNativeMethods.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+using System.Security;
+
+namespace BrushFactory.Interop
+{
+    [SuppressUnmanagedCodeSecurity]
+    internal static class SafeNativeMethods
+    {
+        [DllImport("user32.dll", ExactSpelling = true)]
+        internal static extern short GetKeyState(int keyCode);
+    }
+}


### PR DESCRIPTION
Use P/Invoke to call the Win32 GetKeyState API.
This removes the dependency on the System.Windows.Input.Keyboard class
in PresentationCore.