### PR TITLE
Add support for loading ABR files

### DIFF
--- a/Abr/AbrBrush.cs
+++ b/Abr/AbrBrush.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Drawing;
+
+namespace BrushFactory.Abr
+{
+    internal sealed class AbrBrush : IDisposable
+    {
+        private Bitmap image;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbrBrush"/> class.
+        /// </summary>
+        /// <param name="width">The width of the brush image.</param>
+        /// <param name="height">The height of the brush image.</param>
+        /// <param name="name">The name of the brush.</param>
+        public AbrBrush(int width, int height, string name)
+        {
+            image = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            Name = name;
+        }
+
+        /// <summary>
+        /// Gets the brush image.
+        /// </summary>
+        /// <value>
+        /// The brush image.
+        /// </value>
+        public Bitmap Image
+        {
+            get
+            {
+                if (image == null)
+                {
+                    throw new ObjectDisposedException(nameof(AbrBrush));
+                }
+
+                return image;
+            }
+        }
+
+        /// <summary>
+        /// Gets the brush name.
+        /// </summary>
+        /// <value>
+        /// The brush name.
+        /// </value>
+        public string Name
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            if (image != null)
+            {
+                image.Dispose();
+                image = null;
+            }
+        }
+    }
+}

--- a/Abr/AbrBrushCollection.cs
+++ b/Abr/AbrBrushCollection.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace BrushFactory.Abr
+{
+    internal sealed class AbrBrushCollection : IReadOnlyList<AbrBrush>, IDisposable
+    {
+        private readonly List<AbrBrush> brushes;
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbrBrushCollection"/> class.
+        /// </summary>
+        /// <param name="list">The list of brushes.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="list"/> is null.</exception>
+        public AbrBrushCollection(List<AbrBrush> list)
+        {
+            brushes = list ?? throw new ArgumentNullException(nameof(list));
+            disposed = false;
+        }
+
+        public AbrBrush this[int index]
+        {
+            get
+            {
+                if (disposed)
+                {
+                    throw new ObjectDisposedException(nameof(AbrBrushCollection));
+                }
+
+                return brushes[index];
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                return brushes.Count;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                disposed = true;
+
+                for (int i = 0; i < brushes.Count; i++)
+                {
+                    brushes[i].Dispose();
+                }
+            }
+        }
+
+        public IEnumerator<AbrBrush> GetEnumerator()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(AbrBrushCollection));
+            }
+
+            return brushes.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(AbrBrushCollection));
+            }
+
+            return brushes.GetEnumerator();
+        }
+    }
+}

--- a/Abr/AbrReader.cs
+++ b/Abr/AbrReader.cs
@@ -1,0 +1,513 @@
+﻿/////////////////////////////////////////////////////////////////////////////////
+//
+// ABR FileType Plugin for Paint.NET
+//
+// This software is provided under the MIT License:
+//   Copyright (c) 2012, 2013, 2017, 2018 Nicholas Hayes
+//
+// See LICENSE.txt for complete licensing and attribution information.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+// Portions of this file has been adapted from:
+/////////////////////////////////////////////////////////////////////////////////
+// Paint.NET                                                                   //
+// Copyright (C) dotPDN LLC, Rick Brewster, Tom Jackson, and contributors.     //
+// Portions Copyright (C) Microsoft Corporation. All Rights Reserved.          //
+// See src/Resources/Files/License.txt for full licensing and attribution      //
+// details.                                                                    //
+// .                                                                           //
+/////////////////////////////////////////////////////////////////////////////////
+
+using BrushFactory.Abr.Internal;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace BrushFactory.Abr
+{
+	internal static class AbrReader
+	{
+		private enum BrushType : short
+		{
+			Computed = 1,
+			Sampled
+		}
+
+		private enum BrushCompression
+		{
+			None = 0,
+			RLE = 1
+		}
+
+		/// <summary>
+		/// Loads the brushes from the specified path.
+		/// </summary>
+		/// <param name="path">The path.</param>
+		/// <returns>An <see cref="AbrBrushCollection"/> containing the brushes.</returns>
+		/// <exception cref="FileNotFoundException">The file can not be found.</exception>
+		/// <exception cref="FormatException">The ABR version is not supported.</exception>
+		public static AbrBrushCollection LoadBrushes(string path)
+		{
+			AbrBrushCollection brushes;
+
+			FileStream stream = null;
+
+			try
+			{
+				stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+
+				using (BigEndianBinaryReader reader = new BigEndianBinaryReader(stream))
+				{
+					stream = null;
+
+					short version = reader.ReadInt16();
+
+					switch (version)
+					{
+						case 1:
+						case 2:
+							brushes = DecodeVersion1(reader, version);
+							break;
+						case 6:
+						case 7: // Used by Photoshop CS and later for brushes containing 16-bit data.
+						case 10: // Used by Photoshop CS6 and/or CC?
+							brushes = DecodeVersion6(reader, version);
+							break;
+						default:
+							throw new FormatException(string.Format(CultureInfo.CurrentCulture,
+																	Globalization.GlobalStrings.AbrUnsupportedMajorVersionFormat,
+																	version));
+					}
+				}
+			}
+			finally
+			{
+				if (stream != null)
+				{
+					stream.Dispose();
+					stream = null;
+				}
+			}
+
+			return brushes;
+		}
+
+		/// <summary>
+		/// Decodes the version 1 and 2 brushes.
+		/// </summary>
+		/// <param name="reader">The reader.</param>
+		/// <param name="majorVersion">The major version.</param>
+		/// <returns>An <see cref="AbrBrushCollection"/> containing the brushes.</returns>
+		private static AbrBrushCollection DecodeVersion1(BigEndianBinaryReader reader, short version)
+		{
+			short count = reader.ReadInt16();
+
+			List<AbrBrush> brushes = new List<AbrBrush>(count);
+
+			for (int i = 0; i < count; i++)
+			{
+				BrushType type = (BrushType)reader.ReadInt16();
+				int size = reader.ReadInt32();
+
+				long endOffset = reader.Position + size;
+
+#if DEBUG
+				System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Brush: {0}, type: {1}, size: {2} bytes", i, type, size));
+#endif
+				if (type == BrushType.Computed)
+				{
+#if DEBUG
+					int misc = reader.ReadInt32();
+					short spacing = reader.ReadInt16();
+
+					string name = string.Empty;
+					if (version == 2)
+					{
+						name = reader.ReadUnicodeString();
+					}
+
+					short diameter = reader.ReadInt16();
+					short roundness = reader.ReadInt16();
+					short angle = reader.ReadInt16();
+					short hardness = reader.ReadInt16();
+#else
+					reader.Position += size;
+#endif
+				}
+				else if (type == BrushType.Sampled)
+				{
+					int misc = reader.ReadInt32();
+					short spacing = reader.ReadInt16();
+
+					string name = string.Empty;
+					if (version == 2)
+					{
+						name = reader.ReadUnicodeString();
+					}
+
+					bool antiAlias = reader.ReadByte() != 0;
+
+					// Skip the Int16 bounds.
+					reader.Position += 8L;
+
+					Rectangle bounds = reader.ReadInt32Rectangle();
+					if (bounds.Width <= 0 || bounds.Height <= 0)
+					{
+						// Skip any brushes that have invalid dimensions.
+						reader.Position += (endOffset - reader.Position);
+						continue;
+					}
+
+					short depth = reader.ReadInt16();
+
+					if (depth != 8)
+					{
+						// The format specs state that brushes must be 8-bit, skip any that are not.
+						reader.Position += (endOffset - reader.Position);
+						continue;
+					}
+					int height = bounds.Height;
+					int width = bounds.Width;
+
+					int rowsRemaining = height;
+					int rowsRead = 0;
+
+					byte[] alphaData = new byte[width * height];
+					bool unknownCompressionType = false;
+
+					do
+					{
+						// Sampled brush data is broken into repeating chunks for brushes taller that 16384 pixels.
+						int chunkHeight = Math.Min(rowsRemaining, 16384);
+						// The format specs state that compression is stored as a 2-byte field, but it is written as a 1-byte field in actual files.
+						BrushCompression compression = (BrushCompression)reader.ReadByte();
+
+						if (compression == BrushCompression.RLE)
+						{
+							short[] compressedRowLengths = new short[height];
+
+							for (int y = 0; y < height; y++)
+							{
+								compressedRowLengths[y] = reader.ReadInt16();
+							}
+
+							for (int y = 0; y < chunkHeight; y++)
+							{
+								int row = rowsRead + y;
+								RLEHelper.DecodedRow(reader, alphaData, row * width, width);
+							}
+						}
+						else if (compression == BrushCompression.None)
+						{
+							int numBytesToRead = chunkHeight * width;
+							int numBytesRead = rowsRead * width;
+							while (numBytesToRead > 0)
+							{
+								// Read may return anything from 0 to numBytesToRead.
+								int n = reader.Read(alphaData, numBytesRead, numBytesToRead);
+								// The end of the file is reached.
+								if (n == 0)
+								{
+									break;
+								}
+								numBytesRead += n;
+								numBytesToRead -= n;
+							}
+						}
+						else
+						{
+							// The format specs state that the brush data can be either uncompressed or RLE compressed with PackBits.
+							// Ignore any brushes with an unknown compression type.
+							unknownCompressionType = true;
+							break;
+						}
+
+						rowsRead += 16384;
+						rowsRemaining -= 16384;
+
+					} while (rowsRemaining > 0);
+
+					if (unknownCompressionType)
+					{
+						reader.Position += (endOffset - reader.Position);
+						continue;
+					}
+					else
+					{
+						brushes.Add(CreateSampledBrush(width, height, depth, alphaData, name));
+					}
+				}
+				else
+				{
+					// Skip any unknown brush types.
+					reader.Position += size;
+				}
+			}
+
+			return new AbrBrushCollection(brushes);
+		}
+
+		/// <summary>
+		/// Decodes the descriptor-based brushes in version 6 and later.
+		/// </summary>
+		/// <param name="reader">The reader.</param>
+		/// <param name="majorVersion">The major version.</param>
+		/// <returns>An <see cref="AbrBrushCollection"/> containing the brushes.</returns>
+		/// <exception cref="FormatException">The ABR version is not supported.</exception>
+		private static AbrBrushCollection DecodeVersion6(BigEndianBinaryReader reader, short majorVersion)
+		{
+			short minorVersion = reader.ReadInt16();
+			long unusedDataLength;
+
+			switch (minorVersion)
+			{
+				case 1:
+					// Skip the Int16 bounds rectangle and the unknown Int16.
+					unusedDataLength = 10L;
+					break;
+				case 2:
+					// Skip the unknown bytes.
+					unusedDataLength = 264L;
+					break;
+				default:
+					throw new FormatException(string.Format(CultureInfo.CurrentCulture,
+															Globalization.GlobalStrings.AbrUnsupportedMinorVersionFormat,
+															majorVersion, minorVersion));
+			}
+
+			BrushSectionParser parser = new BrushSectionParser(reader);
+
+			List<AbrBrush> brushes = new List<AbrBrush>(parser.SampledBrushes.Count);
+
+			long sampleSectionOffset = parser.SampleSectionOffset;
+
+			if (parser.SampledBrushes.Count > 0 && sampleSectionOffset >= 0)
+			{
+				reader.Position = sampleSectionOffset;
+
+				uint sectionLength = reader.ReadUInt32();
+
+				long sectionEnd = reader.Position + sectionLength;
+
+				while (reader.Position < sectionEnd)
+				{
+					uint brushLength = reader.ReadUInt32();
+
+					// The brush data is padded to 4 byte alignment.
+					long paddedBrushLength = ((long)brushLength + 3) & ~3;
+
+					long endOffset = reader.Position + paddedBrushLength;
+
+					string tag = reader.ReadPascalString();
+
+					// Skip the unneeded data that comes before the Int32 bounds rectangle.
+					reader.Position += unusedDataLength;
+
+					Rectangle bounds = reader.ReadInt32Rectangle();
+					if (bounds.Width <= 0 || bounds.Height <= 0)
+					{
+						// Skip any brushes that have invalid dimensions.
+						reader.Position += (endOffset - reader.Position);
+						continue;
+					}
+
+					short depth = reader.ReadInt16();
+					if (depth != 8 && depth != 16)
+					{
+						// Skip any brushes with an unknown bit depth.
+						reader.Position += (endOffset - reader.Position);
+						continue;
+					}
+
+					SampledBrush sampledBrush = parser.SampledBrushes.FindLargestBrush(tag);
+					if (sampledBrush != null)
+					{
+						BrushCompression compression = (BrushCompression)reader.ReadByte();
+
+						int height = bounds.Height;
+						int width = bounds.Width;
+
+						byte[] alphaData = null;
+
+						if (compression == BrushCompression.RLE)
+						{
+							short[] compressedRowLengths = new short[height];
+
+							for (int y = 0; y < height; y++)
+							{
+								compressedRowLengths[y] = reader.ReadInt16();
+							}
+
+							int alphaDataSize = width * height;
+							int bytesPerRow = width;
+
+							if (depth == 16)
+							{
+								alphaDataSize *= 2;
+								bytesPerRow *= 2;
+							}
+
+							alphaData = new byte[alphaDataSize];
+
+							for (int y = 0; y < height; y++)
+							{
+								RLEHelper.DecodedRow(reader, alphaData, y * width, bytesPerRow);
+							}
+						}
+						else if (compression == BrushCompression.None)
+						{
+							int alphaDataSize = width * height;
+
+							if (depth == 16)
+							{
+								alphaDataSize *= 2;
+							}
+
+							alphaData = reader.ReadBytes(alphaDataSize);
+						}
+						else
+						{
+							// Skip any brushes with an unknown compression type.
+							reader.Position += (endOffset - reader.Position);
+							continue;
+						}
+
+						AbrBrush brush = CreateSampledBrush(width, height, depth, alphaData, sampledBrush.Name);
+
+						brushes.Add(brush);
+
+						// Some brushes only store the largest item and scale it down.
+						var scaledBrushes = parser.SampledBrushes.Where(i => i.Tag.Equals(tag, StringComparison.Ordinal) && i.Diameter < sampledBrush.Diameter);
+						if (scaledBrushes.Any())
+						{
+							int originalWidth = brush.Image.Width;
+							int originalHeight = brush.Image.Height;
+
+							foreach (SampledBrush item in scaledBrushes.OrderByDescending(p => p.Diameter))
+							{
+								Size size = ComputeBrushSize(originalWidth, originalHeight, item.Diameter);
+
+								AbrBrush scaledBrush = new AbrBrush(size.Width, size.Height, item.Name);
+
+								using (Graphics gr = Graphics.FromImage(scaledBrush.Image))
+								{
+									gr.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.HighQuality;
+									gr.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+									gr.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.HighQuality;
+									gr.DrawImage(brush.Image, 0, 0, size.Width, size.Height);
+								}
+
+								brushes.Add(scaledBrush);
+							}
+						}
+					}
+
+					long remaining = endOffset - reader.Position;
+					// Skip any remaining bytes until the next sampled brush.
+					if (remaining > 0)
+					{
+						reader.Position += remaining;
+					}
+				}
+			}
+
+			return new AbrBrushCollection(brushes);
+		}
+
+		private static unsafe AbrBrush CreateSampledBrush(int width, int height, int depth, byte[] alphaData, string name)
+		{
+			AbrBrush brush = new AbrBrush(width, height, name);
+
+			BitmapData bd = brush.Image.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
+
+			try
+			{
+				fixed (byte* ptr = alphaData)
+				{
+					byte* scan0 = (byte*)bd.Scan0.ToPointer();
+					int stride = bd.Stride;
+
+					if (depth == 16)
+					{
+						int srcStride = width * 2;
+						for (int y = 0; y < height; y++)
+						{
+							byte* src = ptr + (y * srcStride);
+							byte* dst = scan0 + (y * stride);
+
+							for (int x = 0; x < width; x++)
+							{
+								ushort val = (ushort)((src[0] << 8) | src[1]);
+
+								dst[0] = dst[1] = dst[2] = 0;
+								dst[3] = (byte)((val * 10) / 1285);
+
+								src += 2;
+								dst += 4;
+							}
+						}
+					}
+					else
+					{
+						for (int y = 0; y < height; y++)
+						{
+							byte* src = ptr + (y * width);
+							byte* dst = scan0 + (y * stride);
+
+							for (int x = 0; x < width; x++)
+							{
+								dst[0] = dst[1] = dst[2] = 0;
+								dst[3] = *src;
+
+								src++;
+								dst += 4;
+							}
+						}
+					}
+				}
+			}
+			finally
+			{
+				brush.Image.UnlockBits(bd);
+			}
+
+			return brush;
+		}
+
+		private static Size ComputeBrushSize(int originalWidth, int originalHeight, int maxEdgeLength)
+		{
+			Size thumbSize = Size.Empty;
+
+			if (originalWidth <= 0 || originalHeight <= 0)
+			{
+				thumbSize.Width = 1;
+				thumbSize.Height = 1;
+			}
+			else if (originalWidth > originalHeight)
+			{
+				int longSide = Math.Min(originalWidth, maxEdgeLength);
+				thumbSize.Width = longSide;
+				thumbSize.Height = Math.Max(1, (originalHeight * longSide) / originalWidth);
+			}
+			else if (originalHeight > originalWidth)
+			{
+				int longSide = Math.Min(originalHeight, maxEdgeLength);
+				thumbSize.Width = Math.Max(1, (originalWidth * longSide) / originalHeight);
+				thumbSize.Height = longSide;
+			}
+			else
+			{
+				int longSide = Math.Min(originalWidth, maxEdgeLength);
+				thumbSize.Width = longSide;
+				thumbSize.Height = longSide;
+			}
+
+			return thumbSize;
+		}
+	}
+}

--- a/Abr/Internal/BigEndianBinaryReader.cs
+++ b/Abr/Internal/BigEndianBinaryReader.cs
@@ -1,0 +1,531 @@
+﻿/////////////////////////////////////////////////////////////////////////////////
+//
+// ABR FileType Plugin for Paint.NET
+//
+// This software is provided under the MIT License:
+//   Copyright (c) 2012, 2013, 2017, 2018 Nicholas Hayes
+//
+// See LICENSE.txt for complete licensing and attribution information.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+// Portions of this file has been adapted from:
+/////////////////////////////////////////////////////////////////////////////////
+//
+// Photoshop PSD FileType Plugin for Paint.NET
+// http://psdplugin.codeplex.com/
+//
+// This software is provided under the MIT License:
+//   Copyright (c) 2006-2007 Frank Blumenberg
+//   Copyright (c) 2010-2011 Tao Yue
+//
+// Portions of this file are provided under the BSD 3-clause License:
+//   Copyright (c) 2006, Jonas Beckeman
+//
+// See LICENSE.txt for complete licensing and attribution information.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Drawing;
+using System.IO;
+using System.Text;
+
+namespace BrushFactory.Abr.Internal
+{
+    // Adapted from 'Problem and Solution: The Terrible Inefficiency of FileStream and BinaryReader'
+    // https://jacksondunstan.com/articles/3568
+
+    internal sealed class BigEndianBinaryReader : IDisposable
+    {
+        private Stream stream;
+        private byte[] buffer;
+        private int readOffset;
+        private int readLength;
+
+        private readonly int bufferSize;
+
+        private const int MaxBufferSize = 4096;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BigEndianBinaryReader"/> class.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+        public BigEndianBinaryReader(Stream stream)
+        {
+            this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            bufferSize = (int)Math.Min(stream.Length, MaxBufferSize);
+            buffer = new byte[bufferSize];
+            readOffset = 0;
+            readLength = 0;
+        }
+
+        /// <summary>
+        /// Gets the length of the stream.
+        /// </summary>
+        /// <value>
+        /// The length of the stream.
+        /// </value>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public long Length
+        {
+            get
+            {
+                if (stream == null)
+                {
+                    throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+                }
+
+                return stream.Length;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the position in the stream.
+        /// </summary>
+        /// <value>
+        /// The position in the stream.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">value is negative.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public long Position
+        {
+            get
+            {
+                if (stream == null)
+                {
+                    throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+                }
+
+                return stream.Position - readLength + readOffset;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException("value");
+                }
+                if (stream == null)
+                {
+                    throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+                }
+
+                long current = Position;
+
+                if (value != current)
+                {
+                    long diff = value - current;
+
+                    long newOffset = readOffset + diff;
+
+                    // Avoid reading from the stream if the offset is within the current buffer.
+                    if (newOffset >= 0 && newOffset <= readLength)
+                    {
+                        readOffset = (int)newOffset;
+                    }
+                    else
+                    {
+                        // Invalidate the existing buffer.
+                        readOffset = 0;
+                        readLength = 0;
+                        stream.Seek(value, SeekOrigin.Begin);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            if (stream != null)
+            {
+                stream.Dispose();
+                stream = null;
+            }
+        }
+
+        /// <summary>
+        /// Reads the specified number of bytes from the stream, starting from a specified point in the byte array.
+        /// </summary>
+        /// <param name="bytes">The bytes.</param>
+        /// <param name="offset">The starting offset in the array.</param>
+        /// <param name="count">The count.</param>
+        /// <returns>The number of bytes read from the stream.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="bytes"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public int Read(byte[] bytes, int offset, int count)
+        {
+            if (bytes == null)
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            if (count == 0)
+            {
+                return 0;
+            }
+
+            if ((readOffset + count) <= readLength)
+            {
+                Buffer.BlockCopy(buffer, readOffset, bytes, offset, count);
+                readOffset += count;
+
+                return count;
+            }
+            else
+            {
+                // Ensure that any bytes at the end of the current buffer are included.
+                int bytesUnread = readLength - readOffset;
+
+                if (bytesUnread > 0)
+                {
+                    Buffer.BlockCopy(buffer, readOffset, bytes, 0, bytesUnread);
+                }
+
+                // Invalidate the existing buffer.
+                readOffset = 0;
+                readLength = 0;
+
+                int totalBytesRead = bytesUnread;
+
+                totalBytesRead += stream.Read(bytes, offset + bytesUnread, count - bytesUnread);
+
+                return totalBytesRead;
+            }
+        }
+
+        /// <summary>
+        /// Reads the next byte from the current stream.
+        /// </summary>
+        /// <returns>The next byte read from the current stream.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public byte ReadByte()
+        {
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            if ((readOffset + sizeof(byte)) > readLength)
+            {
+                FillBuffer(sizeof(byte));
+            }
+
+            byte val = buffer[readOffset];
+            readOffset += sizeof(byte);
+
+            return val;
+        }
+
+        /// <summary>
+        /// Reads the specified number of bytes from the stream.
+        /// </summary>
+        /// <param name="count">The number of bytes to read..</param>
+        /// <returns>An array containing the specified bytes.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public byte[] ReadBytes(int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            if (count == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            byte[] bytes = new byte[count];
+
+            if ((readOffset + count) <= readLength)
+            {
+                Buffer.BlockCopy(buffer, readOffset, bytes, 0, count);
+                readOffset += count;
+            }
+            else
+            {
+                // Ensure that any bytes at the end of the current buffer are included.
+                int bytesUnread = readLength - readOffset;
+
+                if (bytesUnread > 0)
+                {
+                    Buffer.BlockCopy(buffer, readOffset, bytes, 0, bytesUnread);
+                }
+
+                int numBytesToRead = count - bytesUnread;
+                int numBytesRead = bytesUnread;
+                do
+                {
+                    int n = stream.Read(bytes, numBytesRead, numBytesToRead);
+
+                    if (n == 0)
+                    {
+                        throw new EndOfStreamException();
+                    }
+
+                    numBytesRead += n;
+                    numBytesToRead -= n;
+
+                } while (numBytesToRead > 0);
+
+                // Invalidate the existing buffer.
+                readOffset = 0;
+                readLength = 0;
+            }
+
+            return bytes;
+        }
+
+        /// <summary>
+        /// Reads a 8-byte floating point value in big endian byte order.
+        /// </summary>
+        /// <returns>The 8-byte floating point value.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public unsafe double ReadDouble()
+        {
+            ulong temp = ReadUInt64();
+
+            return *(double*)&temp;
+        }
+
+        /// <summary>
+        /// Reads a 2-byte signed integer in big endian byte order.
+        /// </summary>
+        /// <returns>The 4-byte signed integer.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public short ReadInt16()
+        {
+            return (short)ReadUInt16();
+        }
+
+        /// <summary>
+        /// Reads a 2-byte unsigned integer in big endian byte order.
+        /// </summary>
+        /// <returns>The 2-byte unsigned integer.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public ushort ReadUInt16()
+        {
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            if ((readOffset + sizeof(ushort)) > readLength)
+            {
+                FillBuffer(sizeof(ushort));
+            }
+
+            ushort val = (ushort)((buffer[readOffset] << 8) | buffer[readOffset + 1]);
+            readOffset += sizeof(ushort);
+
+            return val;
+        }
+
+        /// <summary>
+        /// Reads a 4-byte signed integer in big endian byte order.
+        /// </summary>
+        /// <returns>The 4-byte signed integer.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public int ReadInt32()
+        {
+            return (int)ReadUInt32();
+        }
+
+        /// <summary>
+        /// Reads a 4-byte unsigned integer in big endian byte order.
+        /// </summary>
+        /// <returns>The 4-byte unsigned integer.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public uint ReadUInt32()
+        {
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            if ((readOffset + sizeof(uint)) > readLength)
+            {
+                FillBuffer(sizeof(uint));
+            }
+
+            uint val = (uint)((buffer[readOffset] << 24) | (buffer[readOffset + 1] << 16) | (buffer[readOffset + 2] << 8) | buffer[readOffset + 3]);
+            readOffset += sizeof(uint);
+
+            return val;
+        }
+
+        /// <summary>
+        /// Reads a 4-byte floating point value in big endian byte order.
+        /// </summary>
+        /// <returns>The 4-byte floating point value.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public unsafe float ReadSingle()
+        {
+            uint temp = ReadUInt32();
+
+            return *(float*)&temp;
+        }
+
+        /// <summary>
+        /// Reads a 8-byte signed integer in big endian byte order.
+        /// </summary>
+        /// <returns>The 8-byte signed integer.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public long ReadInt64()
+        {
+            return (long)ReadUInt64();
+        }
+
+        /// <summary>
+        /// Reads a 8-byte unsigned integer in big endian byte order.
+        /// </summary>
+        /// <returns>The 8-byte unsigned integer.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public ulong ReadUInt64()
+        {
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            if ((readOffset + sizeof(ulong)) > readLength)
+            {
+                FillBuffer(sizeof(ulong));
+            }
+
+            uint hi = (uint)((buffer[readOffset] << 24) | (buffer[readOffset + 1] << 16) | (buffer[readOffset + 2] << 8) | buffer[readOffset + 3]);
+            uint lo = (uint)((buffer[readOffset + 4] << 24) | (buffer[readOffset + 5] << 16) | (buffer[readOffset + 6] << 8) | buffer[readOffset + 7]);
+            readOffset += sizeof(ulong);
+
+            return (((ulong)hi) << 32) | lo;
+        }
+
+        //////////////////////////////////////////////////////////////////
+
+        /// <summary>
+        /// Reads a Pascal-style string.
+        /// </summary>
+        /// <returns>A string containing the characters of the Pascal-style string.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public string ReadPascalString()
+        {
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            byte stringLength = ReadByte();
+
+            byte[] bytes = ReadBytes(stringLength);
+
+            return Encoding.ASCII.GetString(bytes);
+        }
+
+        /// <summary>
+        /// Reads a rectangle comprised of 4-byte signed integers.
+        /// </summary>
+        /// <returns>A rectangle comprised of 4-byte signed integers.</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public Rectangle ReadInt32Rectangle()
+        {
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            Rectangle rect = new Rectangle();
+
+            rect.Y = ReadInt32();
+            rect.X = ReadInt32();
+            rect.Height = ReadInt32() - rect.Y;
+            rect.Width = ReadInt32() - rect.X;
+
+            return rect;
+        }
+
+        /// <summary>
+        /// Reads a length-prefixed UTF-16 string.
+        /// </summary>
+        /// <returns>A string containing the characters of the UTF-16 string..</returns>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
+        public string ReadUnicodeString()
+        {
+            if (stream == null)
+            {
+                throw new ObjectDisposedException(nameof(BigEndianBinaryReader));
+            }
+
+            int lengthInChars = ReadInt32();
+            byte[] bytes = ReadBytes(lengthInChars * 2);
+
+            return Encoding.BigEndianUnicode.GetString(bytes).TrimEnd('\0');
+        }
+
+        //////////////////////////////////////////////////////////////////
+
+        /// <summary>
+        /// Fills the buffer with at least the number of bytes requested.
+        /// </summary>
+        /// <param name="minBytes">The minimum number of bytes to place in the buffer.</param>
+        /// <exception cref="EndOfStreamException">The end of the stream has been reached.</exception>
+        private void FillBuffer(int minBytes)
+        {
+            int bytesUnread = readLength - readOffset;
+
+            if (bytesUnread > 0)
+            {
+                Buffer.BlockCopy(buffer, readOffset, buffer, 0, bytesUnread);
+            }
+
+            int numBytesToRead = bufferSize - bytesUnread;
+            int numBytesRead = bytesUnread;
+            do
+            {
+                int n = stream.Read(buffer, numBytesRead, numBytesToRead);
+
+                if (n == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                numBytesRead += n;
+                numBytesToRead -= n;
+
+            } while (numBytesRead < minBytes);
+
+            readOffset = 0;
+            readLength = numBytesRead;
+        }
+    }
+}

--- a/Abr/Internal/BrushSectionParser.cs
+++ b/Abr/Internal/BrushSectionParser.cs
@@ -1,0 +1,446 @@
+﻿/////////////////////////////////////////////////////////////////////////////////
+//
+// ABR FileType Plugin for Paint.NET
+//
+// This software is provided under the MIT License:
+//   Copyright (c) 2012, 2013, 2017, 2018 Nicholas Hayes
+//
+// See LICENSE.txt for complete licensing and attribution information.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace BrushFactory.Abr.Internal
+{
+    /// <summary>
+    /// Parser for the 8BIM sections used by ABR version 6 and later.
+    /// </summary>
+    internal sealed class BrushSectionParser
+    {
+        private readonly BrushSectionOffsets sectionOffsets;
+        private readonly SampledBrushCollection sampledBrushes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrushSectionParser"/> class.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        public BrushSectionParser(BigEndianBinaryReader reader)
+        {
+            sectionOffsets = GetBrushSectionOffsets(reader);
+            sampledBrushes = new SampledBrushCollection();
+
+            if (sectionOffsets != null && sectionOffsets.descriptorSectionOffset >= 0)
+            {
+                reader.Position = sectionOffsets.descriptorSectionOffset;
+                ParseBrushDescriptorSection(reader);
+            }
+        }
+
+        private enum DescriptorTypes : uint
+        {
+            Alias = 0x976c6973, // 'alis'
+            Boolean = 0x626f6f6c, // 'bool'
+            String = 0x54455854, // 'TEXT'
+            Class = 0x74797065, // 'type'
+            Descriptor = 0x4f626a63, // 'Objc'
+            Enumerated = 0x656e756d, // 'enum'
+            Float = 0x646f7562, // 'doub'
+            Integer = 0x6c6f6e67, // 'long'
+            List = 0x566c4c73, // 'VlLs'
+            Null = 0x6e756c6c, // 'null'
+            ObjectRefrence = 0x6f626a20, // 'obj '
+            Path = 0x50746820, // 'Pat '
+            UnitFloat = 0x556e7446, // 'UntF'
+        }
+
+        private enum UnitTypes : uint
+        {
+            Angle = 0x23416e67, // '#Ang'
+            Density = 0x2352736c, // '#Rsl'
+            Distance = 0x23526c74,// '#Rlt'
+            None = 0x234e6e65, // '#Nne'
+            Percent = 0x23507263, // '#Prc'
+            Pixel = 0x2350786c // '#Pxl'
+        }
+
+        /// <summary>
+        /// Gets a collection containing the sampled brush information.
+        /// </summary>
+        /// <value>
+        /// The sampled brush information.
+        /// </value>
+        public SampledBrushCollection SampledBrushes
+        {
+            get
+            {
+                return sampledBrushes;
+            }
+        }
+
+        /// <summary>
+        /// Gets the sample section offset.
+        /// </summary>
+        /// <value>
+        /// The sample section offset.
+        /// </value>
+        public long SampleSectionOffset
+        {
+            get
+            {
+                return sectionOffsets?.sampleSectionOffset ?? -1;
+            }
+        }
+
+        private static BrushSectionOffsets GetBrushSectionOffsets(BigEndianBinaryReader reader)
+        {
+            const uint PhotoshopSignature = 0x3842494D; // 8BIM
+            const uint SampleSectionId = 0x73616D70; // samp
+            const uint DescriptorSectionId = 0x64657363; // desc
+
+            long sampleSectionOffset = -1;
+            long descriptorSectionOffset = -1;
+
+            while (reader.Position < reader.Length)
+            {
+                uint sig = reader.ReadUInt32();
+
+                if (sig != PhotoshopSignature)
+                {
+                    return null;
+                }
+
+                uint sectionId = reader.ReadUInt32();
+
+                switch (sectionId)
+                {
+                    case SampleSectionId:
+                        sampleSectionOffset = reader.Position;
+                        break;
+                    case DescriptorSectionId:
+                        descriptorSectionOffset = reader.Position;
+                        break;
+                }
+
+                uint size = reader.ReadUInt32();
+
+                reader.Position += size;
+            }
+
+            return new BrushSectionOffsets(sampleSectionOffset, descriptorSectionOffset);
+        }
+
+        private void ParseBrushDescriptorSection(BigEndianBinaryReader reader)
+        {
+            uint sectionSize = reader.ReadUInt32();
+
+            long sectionEnd = reader.Position + sectionSize;
+            // Skip the unknown data.
+            reader.Position += 22L;
+
+            if (reader.Position < sectionEnd)
+            {
+                string key = ParseKey(reader);
+                DescriptorTypes type = (DescriptorTypes)reader.ReadUInt32();
+
+#if DEBUG
+                System.Diagnostics.Debug.WriteLine(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Item: {0} ({1}) at {2:X8}",
+                    new object[] { key, type, reader.Position }));
+#endif
+
+                ParseType(reader, type);
+            }
+        }
+
+        private static string ParseKey(BigEndianBinaryReader reader)
+        {
+            int length = reader.ReadInt32();
+            if (length == 0)
+            {
+                length = 4;
+            }
+
+            byte[] bytes = reader.ReadBytes(length);
+
+            return Encoding.ASCII.GetString(bytes);
+        }
+
+        private static string ParseClassId(BigEndianBinaryReader reader)
+        {
+            int length = reader.ReadInt32();
+            if (length == 0)
+            {
+                length = 4;
+            }
+
+            return Encoding.ASCII.GetString(reader.ReadBytes(length)).TrimEnd('\0');
+        }
+
+        private void ParseList(BigEndianBinaryReader reader)
+        {
+            uint count = reader.ReadUInt32();
+            for (int i = 0; i < count; i++)
+            {
+                DescriptorTypes type = (DescriptorTypes)reader.ReadUInt32();
+
+                ParseType(reader, type);
+            }
+        }
+
+        private void ParseDescriptor(BigEndianBinaryReader reader)
+        {
+            string name = ParseString(reader);
+
+            string classId = ParseClassId(reader);
+
+            uint count = reader.ReadUInt32();
+
+#if DEBUG
+            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Parsing descriptor '{0}' ({1} items)", classId, count));
+#endif
+            if (classId.Equals("brushPreset", StringComparison.Ordinal))
+            {
+                ParseBrushPreset(reader, count);
+            }
+            else
+            {
+                for (uint i = 0; i < count; i++)
+                {
+                    string key = ParseKey(reader);
+                    DescriptorTypes type = (DescriptorTypes)reader.ReadUInt32();
+
+#if DEBUG
+                    System.Diagnostics.Debug.WriteLine(string.Format(
+                        CultureInfo.CurrentCulture,
+                        "Item {0}: {1} ({2}) at 0x{3:X8}",
+                        new object[] { i, key, type, reader.Position }));
+#endif
+                    ParseType(reader, type);
+                }
+            }
+        }
+
+        private void ParseBrushPreset(BigEndianBinaryReader reader, uint count)
+        {
+            string presetName = null;
+            BrushData brushData = null;
+
+            for (uint i = 0; i < count; i++)
+            {
+                string key = ParseKey(reader);
+                DescriptorTypes type = (DescriptorTypes)reader.ReadUInt32();
+
+#if DEBUG
+                System.Diagnostics.Debug.WriteLine(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "brushPreset item {0}: {1} ({2}) at 0x{3:X8}",
+                    new object[] { i, key, type, reader.Position }));
+#endif
+                if (key.Equals("Nm  ", StringComparison.Ordinal))
+                {
+                    presetName = ParseString(reader);
+                }
+                else if (key.Equals("Brsh", StringComparison.Ordinal) && type == DescriptorTypes.Descriptor)
+                {
+                    brushData = ParseBrushDescriptor(reader);
+                }
+                else
+                {
+                    ParseType(reader, type);
+                }
+            }
+
+            if (brushData != null && !string.IsNullOrEmpty(brushData.sampledDataTag))
+            {
+                sampledBrushes.Add(new SampledBrush(presetName, brushData.sampledDataTag, brushData.diameter));
+            }
+        }
+
+        private BrushData ParseBrushDescriptor(BigEndianBinaryReader reader)
+        {
+            string name = ParseString(reader);
+
+            string classId = ParseClassId(reader);
+
+            uint count = reader.ReadUInt32();
+
+#if DEBUG
+            System.Diagnostics.Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Parsing {0} ({1} items)", classId, count));
+#endif
+
+            BrushData data = null;
+
+            if (classId.Equals("sampledBrush", StringComparison.Ordinal))
+            {
+                data = ParseSampledBrush(reader, count);
+            }
+            else
+            {
+                for (uint i = 0; i < count; i++)
+                {
+                    string key = ParseKey(reader);
+                    DescriptorTypes type = (DescriptorTypes)reader.ReadUInt32();
+
+#if DEBUG
+                    System.Diagnostics.Debug.WriteLine(string.Format(
+                        CultureInfo.CurrentCulture,
+                        "{0} item {1}: {2} ({3}) at 0x{4:X8}",
+                        new object[] { classId, i, key, type, reader.Position }));
+#endif
+                    ParseType(reader, type);
+                }
+            }
+
+            return data;
+        }
+
+        private BrushData ParseSampledBrush(BigEndianBinaryReader reader, uint count)
+        {
+            BrushData data = new BrushData();
+
+            for (uint i = 0; i < count; i++)
+            {
+                string key = ParseKey(reader);
+
+                DescriptorTypes type = (DescriptorTypes)reader.ReadUInt32();
+
+#if DEBUG
+                System.Diagnostics.Debug.WriteLine(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "sampledBrush item {0}: {1} ({2}) at 0x{3:X8}",
+                    new object[] { i, key, type, reader.Position }));
+#endif
+                UnitFloat unitFloat;
+                switch (key)
+                {
+                    case "Dmtr":
+                        unitFloat = ParseUnitFloat(reader);
+                        if (unitFloat.type == UnitTypes.Pixel)
+                        {
+                            data.diameter = (int)unitFloat.value;
+                        }
+                        break;
+                    case "sampledData":
+                        data.sampledDataTag = ParseString(reader);
+                        break;
+                    default:
+                        ParseType(reader, type);
+                        break;
+                }
+            }
+
+            return data;
+        }
+
+        private static string ParseString(BigEndianBinaryReader reader)
+        {
+            return reader.ReadUnicodeString();
+        }
+
+        private static UnitFloat ParseUnitFloat(BigEndianBinaryReader reader)
+        {
+            return new UnitFloat()
+            {
+                type = (UnitTypes)reader.ReadUInt32(),
+                value = reader.ReadDouble()
+            };
+        }
+
+        private static bool ParseBoolean(BigEndianBinaryReader reader)
+        {
+            return reader.ReadByte() != 0;
+        }
+
+        private static uint ParseInteger(BigEndianBinaryReader reader)
+        {
+            return reader.ReadUInt32();
+        }
+
+        private static double ParseFloat(BigEndianBinaryReader reader)
+        {
+            return reader.ReadDouble();
+        }
+
+        private static EnumeratedValue ParseEnumerated(BigEndianBinaryReader reader)
+        {
+            return new EnumeratedValue()
+            {
+                type = ParseKey(reader),
+                value = ParseKey(reader)
+            };
+        }
+
+        private void ParseType(BigEndianBinaryReader reader, DescriptorTypes type)
+        {
+            switch (type)
+            {
+                case DescriptorTypes.List:
+                    ParseList(reader);
+                    break;
+                case DescriptorTypes.Descriptor:
+                    ParseDescriptor(reader);
+                    break;
+                case DescriptorTypes.String:
+                    ParseString(reader);
+                    break;
+                case DescriptorTypes.UnitFloat:
+                    ParseUnitFloat(reader);
+                    break;
+                case DescriptorTypes.Boolean:
+                    ParseBoolean(reader);
+                    break;
+                case DescriptorTypes.Integer:
+                    ParseInteger(reader);
+                    break;
+                case DescriptorTypes.Float:
+                    ParseFloat(reader);
+                    break;
+                case DescriptorTypes.Enumerated:
+                    ParseEnumerated(reader);
+                    break;
+                default:
+                    throw new FormatException(string.Format(CultureInfo.CurrentCulture, "Unsupported brush descriptor type: '{0}'", DescriptorTypeToString(type)));
+            }
+        }
+
+        private static string DescriptorTypeToString(DescriptorTypes type)
+        {
+            byte[] bytes = BitConverter.GetBytes((uint)type);
+            return Encoding.ASCII.GetString(bytes);
+        }
+
+        private struct UnitFloat
+        {
+            public UnitTypes type;
+            public double value;
+        }
+
+        private sealed class BrushData
+        {
+            public int diameter;
+            public string sampledDataTag;
+        }
+
+        private sealed class BrushSectionOffsets
+        {
+            public readonly long sampleSectionOffset;
+            public readonly long descriptorSectionOffset;
+
+            public BrushSectionOffsets(long sampleSectionOffset, long descriptorSectionOffset)
+            {
+                this.sampleSectionOffset = sampleSectionOffset;
+                this.descriptorSectionOffset = descriptorSectionOffset;
+            }
+        }
+
+        private sealed class EnumeratedValue
+        {
+            public string type;
+            public string value;
+        }
+    }
+}

--- a/Abr/Internal/RLEHelper.cs
+++ b/Abr/Internal/RLEHelper.cs
@@ -1,0 +1,72 @@
+﻿/////////////////////////////////////////////////////////////////////////////////
+//
+// ABR FileType Plugin for Paint.NET
+//
+// This software is provided under the MIT License:
+//   Copyright (c) 2012, 2013, 2017, 2018 Nicholas Hayes
+//
+// See LICENSE.txt for complete licensing and attribution information.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+// Portions of this file has been adapted from:
+/////////////////////////////////////////////////////////////////////////////////
+//
+// Photoshop PSD FileType Plugin for Paint.NET
+// http://psdplugin.codeplex.com/
+//
+// This software is provided under the MIT License:
+//   Copyright (c) 2006-2007 Frank Blumenberg
+//   Copyright (c) 2010-2011 Tao Yue
+//
+// Portions of this file are provided under the BSD 3-clause License:
+//   Copyright (c) 2006, Jonas Beckeman
+//
+// See LICENSE.txt for complete licensing and attribution information.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+namespace BrushFactory.Abr.Internal
+{
+    internal static class RLEHelper
+    {
+        public static void DecodedRow(BigEndianBinaryReader reader, byte[] imgData, int startIdx, int columns)
+        {
+            int count = 0;
+            while (count < columns)
+            {
+                byte byteValue = reader.ReadByte();
+
+                int len = byteValue;
+                if (len < 128)
+                {
+                    len++;
+                    while (len != 0 && (startIdx + count) < imgData.Length)
+                    {
+                        byteValue = reader.ReadByte();
+
+                        imgData[startIdx + count] = byteValue;
+                        count++;
+                        len--;
+                    }
+                }
+                else if (len > 128)
+                {
+                    // Next -len+1 bytes in the dest are replicated from next source byte.
+                    // (Interpret len as a negative 8-bit int.)
+                    len ^= 0x0FF;
+                    len += 2;
+
+                    byteValue = reader.ReadByte();
+
+                    while (len != 0 && (startIdx + count) < imgData.Length)
+                    {
+                        imgData[startIdx + count] = byteValue;
+                        count++;
+                        len--;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Abr/Internal/SampledBrush.cs
+++ b/Abr/Internal/SampledBrush.cs
@@ -1,0 +1,35 @@
+﻿/////////////////////////////////////////////////////////////////////////////////
+//
+// ABR FileType Plugin for Paint.NET
+//
+// This software is provided under the MIT License:
+//   Copyright (c) 2012, 2013, 2017, 2018 Nicholas Hayes
+//
+// See LICENSE.txt for complete licensing and attribution information.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+namespace BrushFactory.Abr.Internal
+{
+    internal sealed class SampledBrush
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SampledBrush"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="tag">The tag.</param>
+        /// <param name="diameter">The diameter.</param>
+        public SampledBrush(string name, string tag, int diameter)
+        {
+            Name = name;
+            Tag = tag;
+            Diameter = diameter;
+        }
+
+        public string Name { get; }
+
+        public string Tag { get; }
+
+        public int Diameter { get; }
+    }
+}

--- a/Abr/Internal/SampledBrushCollection.cs
+++ b/Abr/Internal/SampledBrushCollection.cs
@@ -1,0 +1,44 @@
+﻿/////////////////////////////////////////////////////////////////////////////////
+//
+// ABR FileType Plugin for Paint.NET
+//
+// This software is provided under the MIT License:
+//   Copyright (c) 2012, 2013, 2017, 2018 Nicholas Hayes
+//
+// See LICENSE.txt for complete licensing and attribution information.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace BrushFactory.Abr.Internal
+{
+    internal sealed class SampledBrushCollection : Collection<SampledBrush>
+    {
+        /// <summary>
+        /// Finds the largest diameter brush matching the specified tag.
+        /// </summary>
+        /// <param name="tag">The tag.</param>
+        /// <returns>The largest diameter brush matching the specified tag.</returns>
+        public SampledBrush FindLargestBrush(string tag)
+        {
+            IList<SampledBrush> items = Items;
+            SampledBrush brush = null;
+
+            int maxDiameter = 0;
+            for (int i = 0; i < items.Count; i++)
+            {
+                SampledBrush item = items[i];
+                if (item.Tag.Equals(tag, StringComparison.Ordinal) && item.Diameter > maxDiameter)
+                {
+                    maxDiameter = item.Diameter;
+                    brush = item;
+                }
+            }
+
+            return brush;
+        }
+    }
+}

--- a/BrushFactory.csproj
+++ b/BrushFactory.csproj
@@ -101,6 +101,14 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Abr\AbrBrush.cs" />
+    <Compile Include="Abr\AbrBrushCollection.cs" />
+    <Compile Include="Abr\AbrReader.cs" />
+    <Compile Include="Abr\Internal\BigEndianBinaryReader.cs" />
+    <Compile Include="Abr\Internal\BrushSectionParser.cs" />
+    <Compile Include="Abr\Internal\RLEHelper.cs" />
+    <Compile Include="Abr\Internal\SampledBrush.cs" />
+    <Compile Include="Abr\Internal\SampledBrushCollection.cs" />
     <Compile Include="Gui\BrushFactoryPreferences.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Globalization/GlobalStrings.Designer.cs
+++ b/Globalization/GlobalStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace BrushFactory.Globalization {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GlobalStrings {
@@ -57,6 +57,33 @@ namespace BrushFactory.Globalization {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Brush {0}.
+        /// </summary>
+        internal static string AbrBrushNameFallbackFormat {
+            get {
+                return ResourceManager.GetString("AbrBrushNameFallbackFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported ABR version: {0}.
+        /// </summary>
+        internal static string AbrUnsupportedMajorVersionFormat {
+            get {
+                return ResourceManager.GetString("AbrUnsupportedMajorVersionFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported ABR version: {0}.{1}.
+        /// </summary>
+        internal static string AbrUnsupportedMinorVersionFormat {
+            get {
+                return ResourceManager.GetString("AbrUnsupportedMinorVersionFormat", resourceCulture);
             }
         }
         

--- a/Globalization/GlobalStrings.resx
+++ b/Globalization/GlobalStrings.resx
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AbrBrushNameFallbackFormat" xml:space="preserve">
+    <value>Brush {0}</value>
+  </data>
+  <data name="AbrUnsupportedMajorVersionFormat" xml:space="preserve">
+    <value>Unsupported ABR version: {0}</value>
+  </data>
+  <data name="AbrUnsupportedMinorVersionFormat" xml:space="preserve">
+    <value>Unsupported ABR version: {0}.{1}</value>
+  </data>
   <data name="AddFolder" xml:space="preserve">
     <value>Add Folder</value>
   </data>


### PR DESCRIPTION
This removes the need for users to convert Photoshop-compatible brushes
to another image format before use.