### PR TITLE
Move the undo history into a temporary directory

### DIFF
--- a/BrushFactory.csproj
+++ b/BrushFactory.csproj
@@ -123,6 +123,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="SymmetryMode.cs" />
+    <Compile Include="TempDirectory.cs" />
     <Compile Include="UserSettings.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="PersistentSettings.cs" />

--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -487,6 +487,11 @@ namespace BrushFactory
         /// Provides useful messages when hovering over controls.
         /// </summary>
         private Label txtTooltip;
+
+        /// <summary>
+        /// A temporary folder that is deleted when the dialog exits.
+        /// </summary>
+        private TempDirectory tempDir;
         #endregion
 
         #region Constructors
@@ -496,6 +501,10 @@ namespace BrushFactory
         public WinBrushFactory()
         {
             InitializeComponent();
+
+            TempDirectory.CleanupPreviousDirectories();
+            tempDir = new TempDirectory();
+
             InitBrushes();
 
             //Configures items for the smoothing method combobox.
@@ -693,6 +702,24 @@ namespace BrushFactory
             e.Graphics.FillRectangle(colorBrush,
                 new Rectangle(displayCanvasBG.Right, 0, ClientRectangle.Width - displayCanvasBG.Right,
                 this.ClientRectangle.Height));
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (tempDir != null)
+                {
+                    tempDir.Dispose();
+                    tempDir = null;
+                }
+            }
+
+            base.Dispose(disposing);
         }
         #endregion
 
@@ -2604,11 +2631,11 @@ namespace BrushFactory
                 timerRepositionUpdate.Enabled = true;
 
                 //Adds to the list of undo operations.
-                string path = Path.GetTempPath();
+                string path = tempDir.GetTempPathName("HistoryBmp" + undoHistory.Count + ".undo");
 
                 //Saves the drawing to the file and saves the file path.
-                bmpCurrentDrawing.Save(path + "HistoryBmp" + undoHistory.Count + ".undo");
-                undoHistory.Push(path + "HistoryBmp" + undoHistory.Count + ".undo");
+                bmpCurrentDrawing.Save(path);
+                undoHistory.Push(path);
                 if (!bttnUndo.Enabled)
                 {
                     bttnUndo.Enabled = true;
@@ -3108,9 +3135,9 @@ namespace BrushFactory
             if (File.Exists(fileAndPath))
             {
                 //Saves the drawing to the file for undo.
-                string path = Path.GetTempPath();
-                bmpCurrentDrawing.Save(path + "HistoryBmp" + undoHistory.Count + ".undo");
-                undoHistory.Push(path + "HistoryBmp" + undoHistory.Count + ".undo");
+                string path = tempDir.GetTempPathName("HistoryBmp" + undoHistory.Count + ".undo");
+                bmpCurrentDrawing.Save(path);
+                undoHistory.Push(path);
 
                 //Clears the current drawing (in case parts are transparent),
                 //and draws the saved version.
@@ -3165,9 +3192,9 @@ namespace BrushFactory
             if (File.Exists(fileAndPath))
             {
                 //Saves the drawing to the file for redo.
-                string path = Path.GetTempPath();
-                bmpCurrentDrawing.Save(path + "HistoryBmp" + redoHistory.Count + ".redo");
-                redoHistory.Push(path + "HistoryBmp" + redoHistory.Count + ".redo");
+                string path = tempDir.GetTempPathName("HistoryBmp" + redoHistory.Count + ".redo");
+                bmpCurrentDrawing.Save(path);
+                redoHistory.Push(path);
 
                 //Clears the current drawing (in case parts are transparent),
                 //and draws the saved version.

--- a/TempDirectory.cs
+++ b/TempDirectory.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.IO;
+
+namespace BrushFactory
+{
+    /// <summary>
+    /// A temporary directory that auto-deletes when disposed
+    /// </summary>
+    /// <seealso cref="IDisposable"/>
+    internal sealed class TempDirectory : IDisposable
+    {
+        private readonly string tempDir;
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TempDirectory"/> class.
+        /// </summary>
+        public TempDirectory()
+        {
+            tempDir = CreateTempDirectory();
+            disposed = false;
+        }
+
+        /// <summary>
+        /// Deletes any previous temporary directories.
+        /// </summary>
+        public static void CleanupPreviousDirectories()
+        {
+            try
+            {
+                string rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BrushFactory");
+
+                if (Directory.Exists(rootPath))
+                {
+                    foreach (string path in Directory.EnumerateDirectories(rootPath))
+                    {
+                        DeleteTempDirectory(path);
+                    }
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                disposed = true;
+
+                DeleteTempDirectory(tempDir);
+            }
+        }
+
+        /// <summary>
+        /// Gets a random file name in the directory.
+        /// </summary>
+        /// <returns>A random file name in the directory.</returns>
+        public string GetRandomFileName()
+        {
+            return Path.Combine(tempDir, Path.GetRandomFileName());
+        }
+
+        /// <summary>
+        /// Gets the path of a temporary file with the specified name.
+        /// </summary>
+        /// <returns>The path of the temporary file.</returns>
+        public string GetTempPathName(string fileName)
+        {
+            return Path.Combine(tempDir, fileName);
+        }
+
+        /// <summary>
+        /// Creates the temporary directory.
+        /// </summary>
+        /// <returns>The path of the created directory.</returns>
+        private static string CreateTempDirectory()
+        {
+            string rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BrushFactory");
+
+            DirectoryInfo directoryInfo = new DirectoryInfo(rootPath);
+            if (!directoryInfo.Exists)
+            {
+                directoryInfo.Create();
+            }
+
+            while (true)
+            {
+                string tempDirectoryPath = Path.Combine(rootPath, Path.GetRandomFileName());
+
+                try
+                {
+                    Directory.CreateDirectory(tempDirectoryPath);
+
+                    return tempDirectoryPath;
+                }
+                catch (IOException)
+                {
+                    // Try again if the directory is a file that already exists.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Deletes the temporary directory and all of its contents.
+        /// </summary>
+        /// <param name="path">The path pf the temporary directory.</param>
+        private static void DeleteTempDirectory(string path)
+        {
+            try
+            {
+                foreach (string item in Directory.EnumerateDirectories(path))
+                {
+                    Directory.Delete(item, true);
+                }
+
+                Directory.Delete(path, true);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
This prevents the undo history from being lost if the user's temp
folder is emptied when the dialog is open.
It also allows the files to be deleted when the dialog is closed.