### PR TITLE
Downscale brushes larger than the maximum brush size

### DIFF
--- a/Abr/AbrReader.cs
+++ b/Abr/AbrReader.cs
@@ -9,16 +9,6 @@
 //
 /////////////////////////////////////////////////////////////////////////////////
 
-// Portions of this file has been adapted from:
-/////////////////////////////////////////////////////////////////////////////////
-// Paint.NET                                                                   //
-// Copyright (C) dotPDN LLC, Rick Brewster, Tom Jackson, and contributors.     //
-// Portions Copyright (C) Microsoft Corporation. All Rights Reserved.          //
-// See src/Resources/Files/License.txt for full licensing and attribution      //
-// details.                                                                    //
-// .                                                                           //
-/////////////////////////////////////////////////////////////////////////////////
-
 using BrushFactory.Abr.Internal;
 using System;
 using System.Collections.Generic;
@@ -395,7 +385,7 @@ namespace BrushFactory.Abr
 
 							foreach (SampledBrush item in scaledBrushes.OrderByDescending(p => p.Diameter))
 							{
-								Size size = ComputeBrushSize(originalWidth, originalHeight, item.Diameter);
+								Size size = Utils.ComputeBrushSize(originalWidth, originalHeight, item.Diameter);
 
 								AbrBrush scaledBrush = new AbrBrush(size.Width, size.Height, item.Name);
 
@@ -505,44 +495,6 @@ namespace BrushFactory.Abr
 			}
 
 			return brush;
-		}
-
-        /// <summary>
-        /// Returns the size of the brush after scaling.
-        /// </summary>
-        /// <param name="maxEdgeLength">
-        /// Width or height, whichever is largest. Used to determine new size.
-        /// </param>
-        /// <returns>A Size with the new brush dimensions.</returns>
-		private static Size ComputeBrushSize(int originalWidth, int originalHeight, int maxEdgeLength)
-		{
-			Size thumbSize = Size.Empty;
-
-			if (originalWidth <= 0 || originalHeight <= 0)
-			{
-				thumbSize.Width = 1;
-				thumbSize.Height = 1;
-			}
-			else if (originalWidth > originalHeight)
-			{
-				int longSide = Math.Min(originalWidth, maxEdgeLength);
-				thumbSize.Width = longSide;
-				thumbSize.Height = Math.Max(1, (originalHeight * longSide) / originalWidth);
-			}
-			else if (originalHeight > originalWidth)
-			{
-				int longSide = Math.Min(originalHeight, maxEdgeLength);
-				thumbSize.Width = Math.Max(1, (originalWidth * longSide) / originalHeight);
-				thumbSize.Height = longSide;
-			}
-			else
-			{
-				int longSide = Math.Min(originalWidth, maxEdgeLength);
-				thumbSize.Width = longSide;
-				thumbSize.Height = longSide;
-			}
-
-			return thumbSize;
 		}
 	}
 }

--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -1299,6 +1299,8 @@ namespace BrushFactory
             bool doAddToSettings,
             bool doDisplayErrors)
         {
+            int maxBrushSize = sliderBrushSize.Maximum;
+
             //Attempts to load a bitmap from a file to use as a brush.
             foreach (string file in filePaths)
             {
@@ -1316,13 +1318,30 @@ namespace BrushFactory
 
                                     // Creates the brush space.
                                     int size = Math.Max(item.Image.Width, item.Image.Height);
+
+                                    Bitmap scaledBrush = null;
+                                    if (size > maxBrushSize)
+                                    {
+                                        size = maxBrushSize;
+
+                                        Size newImageSize = Utils.ComputeBrushSize(item.Image.Width, item.Image.Height, maxBrushSize);
+
+                                        scaledBrush = Utils.DownscaleImage(item.Image, newImageSize);
+                                    }
+
                                     bmpBrush = new Bitmap(size, size);
 
                                     //Pads the image to be square if needed, makes fully
                                     //opaque images use intensity for alpha, and draws the
                                     //altered loaded bitmap to the brush.
                                     Utils.CopyBitmapPure(Utils.MakeBitmapSquare(
-                                        Utils.MakeTransparent(item.Image)), bmpBrush);
+                                        Utils.MakeTransparent(scaledBrush ?? item.Image)), bmpBrush);
+
+                                    if (scaledBrush != null)
+                                    {
+                                        scaledBrush.Dispose();
+                                        scaledBrush = null;
+                                    }
 
                                     string filename = item.Name;
                                     if (string.IsNullOrEmpty(filename))
@@ -1357,13 +1376,30 @@ namespace BrushFactory
                         {
                             //Creates the brush space.
                             int size = Math.Max(bmp.Width, bmp.Height);
+
+                            Bitmap scaledBrush = null;
+                            if (size > maxBrushSize)
+                            {
+                                size = maxBrushSize;
+
+                                Size newImageSize = Utils.ComputeBrushSize(bmp.Width, bmp.Height, maxBrushSize);
+
+                                scaledBrush = Utils.DownscaleImage(bmp, newImageSize);
+                            }
+
                             bmpBrush = new Bitmap(size, size);
 
                             //Pads the image to be square if needed, makes fully
                             //opaque images use intensity for alpha, and draws the
                             //altered loaded bitmap to the brush.
                             Utils.CopyBitmapPure(Utils.MakeBitmapSquare(
-                                Utils.MakeTransparent(bmp)), bmpBrush);
+                                Utils.MakeTransparent(scaledBrush ?? bmp)), bmpBrush);
+
+                            if (scaledBrush != null)
+                            {
+                                scaledBrush.Dispose();
+                                scaledBrush = null;
+                            }
                         }
 
                         //Gets the last word in the filename without the path.

--- a/Utils.cs
+++ b/Utils.cs
@@ -1,4 +1,14 @@
-﻿using PaintDotNet;
+﻿// Portions of this file has been adapted from:
+/////////////////////////////////////////////////////////////////////////////////
+// Paint.NET                                                                   //
+// Copyright (C) dotPDN LLC, Rick Brewster, Tom Jackson, and contributors.     //
+// Portions Copyright (C) Microsoft Corporation. All Rights Reserved.          //
+// See src/Resources/Files/License.txt for full licensing and attribution      //
+// details.                                                                    //
+// .                                                                           //
+/////////////////////////////////////////////////////////////////////////////////
+
+using PaintDotNet;
 using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -459,6 +469,66 @@ namespace BrushFactory
                 return newBmp;
             }
         }
-        #endregion
-    }
+
+		/// <summary>
+		/// Returns the size of the brush after scaling.
+		/// </summary>
+		/// <param name="maxEdgeLength">
+		/// Width or height, whichever is largest. Used to determine new size.
+		/// </param>
+		/// <returns>A Size with the new brush dimensions.</returns>
+		public static Size ComputeBrushSize(int originalWidth, int originalHeight, int maxEdgeLength)
+		{
+			Size thumbSize = Size.Empty;
+
+			if (originalWidth <= 0 || originalHeight <= 0)
+			{
+				thumbSize.Width = 1;
+				thumbSize.Height = 1;
+			}
+			else if (originalWidth > originalHeight)
+			{
+				int longSide = Math.Min(originalWidth, maxEdgeLength);
+				thumbSize.Width = longSide;
+				thumbSize.Height = Math.Max(1, (originalHeight * longSide) / originalWidth);
+			}
+			else if (originalHeight > originalWidth)
+			{
+				int longSide = Math.Min(originalHeight, maxEdgeLength);
+				thumbSize.Width = Math.Max(1, (originalWidth * longSide) / originalHeight);
+				thumbSize.Height = longSide;
+			}
+			else
+			{
+				int longSide = Math.Min(originalWidth, maxEdgeLength);
+				thumbSize.Width = longSide;
+				thumbSize.Height = longSide;
+			}
+
+			return thumbSize;
+		}
+
+		/// <summary>
+		/// Downscales the image to the specified size.
+		/// </summary>
+		/// <param name="image">The image.</param>
+		/// <param name="newSize">The new size.</param>
+		/// <returns>The downscaled image.</returns>
+		public static Bitmap DownscaleImage(Bitmap image, Size newSize)
+		{
+			Bitmap scaled = new Bitmap(newSize.Width, newSize.Height);
+
+			using (Graphics gr = Graphics.FromImage(scaled))
+			{
+				gr.SmoothingMode = SmoothingMode.HighQuality;
+				gr.InterpolationMode = InterpolationMode.HighQualityBicubic;
+				gr.PixelOffsetMode = PixelOffsetMode.HighQuality;
+
+				gr.DrawImage(image, 0, 0, newSize.Width, newSize.Height);
+			}
+
+			return scaled;
+		}
+		#endregion
+	}
 }


### PR DESCRIPTION
It is a waste of memory to have brushes that are larger than the plugin
can render.