### PR TITLE
Store the final image as a Paint.NET Surface

### DIFF
--- a/BrushFactoryEffect.cs
+++ b/BrushFactoryEffect.cs
@@ -206,21 +206,9 @@ namespace BrushFactory
                 //The effect should only render once.
                 RenderSettings.EffectApplied = true;
 
-                using (Graphics g = new RenderArgs(dstArgs.Surface).Graphics)
-                {
-                    //Copies the drawn image, clipping it to the selection.
-                    g.CompositingMode = CompositingMode.SourceCopy;
-                    Region region = new Region(EnvironmentParameters
-                        .GetSelection(srcArgs.Bounds).GetRegionData());
-                    g.SetClip(region, CombineMode.Replace);
-
-                    g.DrawImage(RenderSettings.BmpToRender, 0, 0,
-                        RenderSettings.BmpToRender.Width,
-                        RenderSettings.BmpToRender.Height);
-
-                    //TODO: This copies perfectly, but can't handle clipping to a region.
-                    //Utils.CopyBitmapPure(RenderSettings.BmpToRender, dstArgs.Bitmap);
-                }
+                dstArgs.Surface.CopySurface(
+                    RenderSettings.SurfaceToRender,
+                    EnvironmentParameters.GetSelection(srcArgs.Bounds));
             }
         }
         #endregion

--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -3115,9 +3115,9 @@ namespace BrushFactory
             bttnOk.Enabled = false;
 
             //Sets the bitmap to draw. Locks to prevent concurrency.
-            lock (RenderSettings.BmpToRender)
+            lock (RenderSettings.SurfaceToRender)
             {
-                RenderSettings.BmpToRender = new Bitmap(bmpCurrentDrawing);
+                RenderSettings.SurfaceToRender = Surface.CopyFromBitmap(bmpCurrentDrawing);
             }
 
             //Updates the saved effect settings and OKs the effect.

--- a/RenderSettings.cs
+++ b/RenderSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+﻿using PaintDotNet;
 
 namespace BrushFactory
 {
@@ -8,8 +8,8 @@ namespace BrushFactory
     static class RenderSettings
     {
         #region Fields
-        //The bitmap to render as the final product.
-        private static Bitmap bmpToRender;
+        //The surface to render as the final product.
+        private static Surface surfaceToRender;
 
         //Whether or not to save settings for the dialog.
         private static bool doApplyEffect;
@@ -22,19 +22,19 @@ namespace BrushFactory
 
         #region Properties
         /// <summary>
-        /// The bitmap to render as the final product.
+        /// The surface to render as the final product.
         /// </summary>
-        public static Bitmap BmpToRender
+        public static Surface SurfaceToRender
         {
             get
             {
-                return bmpToRender;
+                return surfaceToRender;
             }
             set
             {
-                bmpToRender?.Dispose();
+                surfaceToRender?.Dispose();
 
-                bmpToRender = value;
+                surfaceToRender = value;
             }
         }
 
@@ -85,7 +85,7 @@ namespace BrushFactory
         /// </summary>
         public static void Clear()
         {
-            BmpToRender = new Bitmap(1, 1);
+            SurfaceToRender = new Surface(1, 1);
             doApplyEffect = false;
             effectApplied = false;
         }

--- a/RenderSettings.cs
+++ b/RenderSettings.cs
@@ -32,6 +32,8 @@ namespace BrushFactory
             }
             set
             {
+                bmpToRender?.Dispose();
+
                 bmpToRender = value;
             }
         }


### PR DESCRIPTION
This reduces the amount of code required to render the final image to the destination surface and should also improve performance.