### PR TITLE
Fix the image scaling code in ComputeBrushSize

### DIFF
--- a/Utils.cs
+++ b/Utils.cs
@@ -471,15 +471,9 @@ namespace BrushFactory
                 return new Size(1, 1);
             }
 
-            int shortestSide = (int)Math.Ceiling(
-                maxDimensionSize / (float)origHeight * origWidth);
+            double scaleRatio = Math.Min((double)maxDimensionSize / origWidth, (double)maxDimensionSize / origHeight);
 
-            if (origWidth >= origHeight)
-            {
-                return new Size(maxDimensionSize, shortestSide);
-            }
-
-            return new Size(shortestSide, maxDimensionSize);
+            return new Size((int)Math.Round(origWidth * scaleRatio), (int)Math.Round(origHeight * scaleRatio));
         }
 
         /// <summary>


### PR DESCRIPTION
The code added in https://github.com/JoshuaLamusga/Brush-Factory/commit/6b1be929354572fb45a9dec1ca4f98abb645be29
produces incorrect dimensions when scaling images.

This causes any image that is down-scaled to be displayed as a blank
spot in the brush list.