### PR TITLE
Use FileMode.Create when writing the settings

### DIFF
--- a/Gui/BrushFactorySettings.cs
+++ b/Gui/BrushFactorySettings.cs
@@ -210,7 +210,7 @@ namespace BrushFactory
                 }
             }
 
-            using (FileStream stream = new FileStream(settingsPath, FileMode.OpenOrCreate, FileAccess.Write))
+            using (FileStream stream = new FileStream(settingsPath, FileMode.Create, FileAccess.Write))
             {
                 DataContractSerializer serializer = new DataContractSerializer(typeof(BrushFactorySettings));
                 serializer.WriteObject(stream, this);


### PR DESCRIPTION
Using FileMode.OpenOrCreate can leave fragments of the previous XML
data at the end of the file.
This will cause the DataContractSerializer to return an error when it
tries to read the saved file.