### PR TITLE
Handle missing directories when loading brushes

### DIFF
--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -1784,6 +1784,9 @@ namespace BrushFactory
                 {
                     continue;
                 }
+                catch (DirectoryNotFoundException)
+                {
+                }
                 catch (FileNotFoundException)
                 {
                     continue;


### PR DESCRIPTION
Added a catch block for the DirectoryNotFoundException.