### PR TITLE
Clear the loaded brushes in InitBrushes

### DIFF
--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -1071,6 +1071,13 @@ namespace BrushFactory
         {
             bmpBrush = new Bitmap(Resources.BrCircle);
 
+            if (loadedBrushes.Count > 0)
+            {
+                // Disposes and removes all of the existing items in the collection.
+                bttnBrushSelector.VirtualListSize = 0;
+                loadedBrushes.Clear();
+            }
+
             //Loads stored brushes.
             loadedBrushes.Add(new BrushSelectorItem("Circle 1", Resources.BrCircle));
 


### PR DESCRIPTION
This fixes a regression with the brush list being duplicated when the
user clears the custom brushes in the UI.