### PR TITLE
Fix an object disposed crash in RepositionUpdate_Tick

### DIFF
--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -3914,6 +3914,11 @@ namespace BrushFactory
         /// </summary>
         private void RepositionUpdate_Tick(object sender, EventArgs e)
         {
+            if (displayCanvasBG.IsDisposed)
+            {
+                return;
+            }
+
             // Converts the mouse coordinates on the screen relative to the
             // background such that the top-left corner is (0, 0) up to its
             // width and height.


### PR DESCRIPTION
Check if the displayCanvasBG field has been disposed before calling its
PointToClient method.