### PR TITLE
Simplify the error handling when settings fail to load

### DIFF
--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -571,17 +571,10 @@ namespace BrushFactory
                 // to be used if an error occurs.
                 settings.LoadSavedSettings();
             }
-            catch (Exception ex)
+            catch
             {
-                if (ex is IOException || ex is UnauthorizedAccessException)
-                {
-                    MessageBox.Show(Localization.Strings.CannotLoadSettingsError,
-                        Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-                else
-                {
-                    throw;
-                }
+                MessageBox.Show(Localization.Strings.CannotLoadSettingsError,
+                    Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             InitBrushes();


### PR DESCRIPTION
Because the exception message is not shown to the user the code can be
changed to a catch block that swallows all exceptions.