### PR TITLE
 Use pre-multiplied alpha when drawing images

### DIFF
--- a/Abr/AbrBrush.cs
+++ b/Abr/AbrBrush.cs
@@ -18,7 +18,7 @@ namespace BrushFactory.Abr
         /// <param name="name">The name of the brush.</param>
         public AbrBrush(int width, int height, string name)
         {
-            image = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            image = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format32bppPArgb);
             Name = name;
         }
 

--- a/Abr/AbrReader.cs
+++ b/Abr/AbrReader.cs
@@ -441,7 +441,7 @@ namespace BrushFactory.Abr
 			BitmapData bd = brush.Image.LockBits(
                 new Rectangle(0, 0, width, height),
                 ImageLockMode.WriteOnly,
-                PixelFormat.Format32bppArgb);
+                PixelFormat.Format32bppPArgb);
 
 			try
 			{

--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -40,7 +40,7 @@ namespace BrushFactory
         /// <summary>
         /// Stores the current drawing in full.
         /// </summary>
-        private Bitmap bmpCurrentDrawing = new Bitmap(1, 1);
+        private Bitmap bmpCurrentDrawing = new Bitmap(1, 1, PixelFormat.Format32bppPArgb);
 
         /// <summary>
         /// Loads user's custom brushes asynchronously.
@@ -2460,7 +2460,7 @@ namespace BrushFactory
             if (bmpBrush != null)
             {
                 //Applies the color and alpha changes.
-                bmpBrushEffects = new Bitmap(bmpBrush);
+                bmpBrushEffects = Utils.FormatImage(bmpBrush, PixelFormat.Format32bppPArgb);
 
                 //Colorizes the image only if enabled.
                 if (chkbxColorizeBrush.Checked)
@@ -2563,7 +2563,7 @@ namespace BrushFactory
                                             scaledBrush = Utils.ScaleImage(item.Image, newImageSize);
                                         }
 
-                                        Bitmap brushImage = new Bitmap(size, size);
+                                        Bitmap brushImage = new Bitmap(size, size, PixelFormat.Format32bppPArgb);
 
                                         //Pads the image to be square if needed, makes fully
                                         //opaque images use intensity for alpha, and draws the
@@ -2629,7 +2629,7 @@ namespace BrushFactory
                                     scaledBrush = Utils.ScaleImage(bmp, newImageSize);
                                 }
 
-                                brushImage = new Bitmap(size, size);
+                                brushImage = new Bitmap(size, size, PixelFormat.Format32bppPArgb);
 
                                 //Pads the image to be square if needed, makes fully
                                 //opaque images use intensity for alpha, and draws the
@@ -3226,8 +3226,8 @@ namespace BrushFactory
 
                     bmpBrush?.Dispose();
                     bmpBrush = Utils.FormatImage(
-                        new Bitmap(currentItem.Brush),
-                        PixelFormat.Format32bppArgb);
+                        currentItem.Brush,
+                        PixelFormat.Format32bppPArgb);
 
                     UpdateBrush();
                 }

--- a/Utils.cs
+++ b/Utils.cs
@@ -71,12 +71,12 @@ namespace BrushFactory
                 for (int x = 0; x < img.Width; x++)
                 {
                     int ptr = y * bmpData.Stride + x * 4;
-                    Color pixel = Color.FromArgb(row[ptr + 3], row[ptr + 2], row[ptr + 1], row[ptr]);
+                    ColorBgra pixel = ColorBgra.FromBgra(color.B, color.G, color.R, (byte)(row[ptr + 3] * alpha)).ConvertToPremultipliedAlpha();
 
-                    row[ptr + 3] = (byte)(pixel.A * alpha);
-                    row[ptr + 2] = color.R;
-                    row[ptr + 1] = color.G;
-                    row[ptr] = color.B;
+                    row[ptr + 3] = pixel.A;
+                    row[ptr + 2] = pixel.R;
+                    row[ptr + 1] = pixel.G;
+                    row[ptr] = pixel.B;
                 }
             }
             img.UnlockBits(bmpData);
@@ -104,9 +104,16 @@ namespace BrushFactory
                 for (int x = 0; x < img.Width; x++)
                 {
                     int ptr = y * bmpData.Stride + x * 4;
-                    Color pixel = Color.FromArgb(row[ptr + 3], row[ptr + 2], row[ptr + 1], row[ptr]);
+                    ColorBgra unmultipliedPixel = ColorBgra.FromBgra(row[ptr], row[ptr + 1], row[ptr + 2], row[ptr + 3]).ConvertFromPremultipliedAlpha();
 
-                    row[ptr + 3] = (byte)(pixel.A * alpha);
+                    unmultipliedPixel.A = (byte)(unmultipliedPixel.A * alpha);
+
+                    ColorBgra premultiplied = unmultipliedPixel.ConvertToPremultipliedAlpha();
+
+                    row[ptr + 3] = premultiplied.A;
+                    row[ptr + 2] = premultiplied.R;
+                    row[ptr + 1] = premultiplied.G;
+                    row[ptr] = premultiplied.B;
                 }
             }
             img.UnlockBits(bmpData);
@@ -147,7 +154,7 @@ namespace BrushFactory
 
         /// <summary>
         /// Overwrites alpha from one identically-sized bitmap on another.
-        /// Both images must have PixelFormat.Format32bppArgb.
+        /// Both images must have PixelFormat.Format32bppPArgb.
         /// Returns success.
         /// </summary>
         /// <param name="srcImg">
@@ -159,8 +166,8 @@ namespace BrushFactory
         public static unsafe bool CopyAlpha(Bitmap srcImg, Bitmap dstImg)
         {
             //Formats and size must be the same.
-            if (srcImg.PixelFormat != PixelFormat.Format32bppArgb ||
-                dstImg.PixelFormat != PixelFormat.Format32bppArgb ||
+            if (srcImg.PixelFormat != PixelFormat.Format32bppPArgb ||
+                dstImg.PixelFormat != PixelFormat.Format32bppPArgb ||
                 srcImg.Width != dstImg.Width ||
                 srcImg.Height != dstImg.Height)
             {
@@ -215,8 +222,8 @@ namespace BrushFactory
             //TODO: Find the underlying issue and stop using workarounds.
 
             //Formats and size must be the same.
-                if (srcImg.PixelFormat != PixelFormat.Format32bppArgb ||
-                dstImg.PixelFormat != PixelFormat.Format32bppArgb ||
+                if (srcImg.PixelFormat != PixelFormat.Format32bppPArgb ||
+                dstImg.PixelFormat != PixelFormat.Format32bppPArgb ||
                 srcImg.Width != dstImg.Width ||
                 srcImg.Height != dstImg.Height)
             {
@@ -266,7 +273,7 @@ namespace BrushFactory
         /// <returns>The created bitmap.</returns>
         public static unsafe Bitmap CreateBitmapFromSurface(Surface surface)
         {
-            Bitmap image = new Bitmap(surface.Width, surface.Height, PixelFormat.Format32bppArgb);
+            Bitmap image = new Bitmap(surface.Width, surface.Height, PixelFormat.Format32bppPArgb);
 
             BitmapData bitmapData = image.LockBits(
                 new Rectangle(0, 0, image.Width, image.Height),
@@ -285,7 +292,7 @@ namespace BrushFactory
 
                 for (int x = 0; x < surface.Width; x++)
                 {
-                    dst->Bgra = src->Bgra;
+                    dst->Bgra = src->ConvertToPremultipliedAlpha().Bgra;
 
                     src++;
                     dst++;
@@ -367,7 +374,7 @@ namespace BrushFactory
         /// <param name="alpha">A value from 0 to 1 to multiply with.</param>
         public static unsafe Bitmap MakeTransparent(Bitmap img)
         {
-            Bitmap image = FormatImage(img, PixelFormat.Format32bppArgb);
+            Bitmap image = FormatImage(img, PixelFormat.Format32bppPArgb);
 
             BitmapData bmpData = image.LockBits(
                 new Rectangle(0, 0,
@@ -427,7 +434,7 @@ namespace BrushFactory
 
             //Creates a new bitmap with the minimum square size.
             int size = Math.Max(img.Height, img.Width);
-            Bitmap newImg = new Bitmap(size, size);
+            Bitmap newImg = new Bitmap(size, size, PixelFormat.Format32bppPArgb);
 
             using (Graphics graphics = Graphics.FromImage(newImg))
             {
@@ -475,7 +482,7 @@ namespace BrushFactory
             int newHeight = (int)Math.Ceiling(origBmp.Width * sin + origBmp.Height * cos);
 
             //Creates the new image and a graphic canvas to draw the rotation.
-            Bitmap newBmp = new Bitmap(newWidth, newHeight);
+            Bitmap newBmp = new Bitmap(newWidth, newHeight, PixelFormat.Format32bppPArgb);
             using (Graphics g = Graphics.FromImage(newBmp))
             {
                 //Uses matrices to centrally-rotate the original image.
@@ -526,7 +533,7 @@ namespace BrushFactory
         public static Bitmap ScaleImage(Bitmap origBmp, Size newSize)
         {
             //Creates the new image and a graphic canvas to draw the rotation.
-            Bitmap newBmp = new Bitmap(newSize.Width, newSize.Height);
+            Bitmap newBmp = new Bitmap(newSize.Width, newSize.Height, PixelFormat.Format32bppPArgb);
             using (Graphics g = Graphics.FromImage(newBmp))
             {
                 g.SmoothingMode = SmoothingMode.AntiAlias;


### PR DESCRIPTION
Drawing all images using the 32PArgb pixels format fixes the various bugs that GDI+ exhibits with drawing 32Argb images with transparency.
It may also improve the performance of various GDI+ methods.

Resolves #1.