### PR TITLE
Zoom at point; not dead center

### DIFF
--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -80,6 +80,8 @@ namespace BrushFactory
         private bool isUserDrawing = false;
         private bool isUserPanning = false;
 
+        private bool isWheelZooming = false;
+
         /// <summary>
         /// Creates the list of brushes used by the brush selector.
         /// </summary>
@@ -728,6 +730,7 @@ namespace BrushFactory
                 //Ctrl + Wheel: Zooms the canvas in/out.
                 else
                 {
+                    isWheelZooming = true;
                     Zoom(e.Delta, true);
                 }
             }
@@ -990,10 +993,22 @@ namespace BrushFactory
             int zoomWidth = (int)(bmpCurrentDrawing.Width * newZoomFactor);
             int zoomHeight = (int)(bmpCurrentDrawing.Height * newZoomFactor);
 
+            Point zoomingPoint = isWheelZooming
+                ? mouseLoc
+                : new Point(
+                    displayCanvasBG.ClientSize.Width / 2 - displayCanvas.Location.X,
+                    displayCanvasBG.ClientSize.Height / 2 - displayCanvas.Location.Y);
+
+            int zoomX = displayCanvas.Location.X + zoomingPoint.X -
+                zoomingPoint.X * zoomWidth / displayCanvas.Width;
+            int zoomY = displayCanvas.Location.Y + zoomingPoint.Y -
+                zoomingPoint.Y * zoomHeight / displayCanvas.Height;
+
+            isWheelZooming = false;
+
             //Sets the new canvas position (center) and size using zoom.
             displayCanvas.Bounds = new Rectangle(
-                (displayCanvasBG.Width - zoomWidth) / 2,
-                (displayCanvasBG.Height - zoomHeight) / 2,
+                zoomX, zoomY,
                 zoomWidth, zoomHeight);
         }
 


### PR DESCRIPTION
This causes zoom to happen at a specific point, instead of the dead center of the canvas.

It can be one of two points:
- The center of the viewport --- if using the slider control
- The mouse cursor location --- if using the mouse wheel