### PR TITLE
Add a FastDebug build configuration

### DIFF
--- a/DynamicDraw.csproj
+++ b/DynamicDraw.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-    <OutputType>Library</OutputType>
     <StartupObject></StartupObject>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -23,6 +22,7 @@
     <Deterministic>false</Deterministic>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <OutputPath></OutputPath>
+    <Configurations>Debug;Release;FastDebug</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PaintDotNet.Base">
@@ -100,14 +100,23 @@
   </ItemGroup>
   <PropertyGroup />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <NoWarn>1701;1702;CA1416;IDE0090;IDE0063</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FastDebug|AnyCPU'">
+    <OutputType>WinExe</OutputType>
+    <DefineConstants>FASTDEBUG;DEBUG;TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <NoWarn>1701;1702;CA1416;IDE0090;IDE0063</NoWarn>
+  </PropertyGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="mkdir -p &quot;C:\Program Files\paint.net\Effects\DynamicDraw&quot;&#xD;&#xA;move &quot;$(TargetPath)&quot; &quot;C:\Program Files\paint.net\Effects\DynamicDraw&quot;&#xD;&#xA;move &quot;$(TargetDir)\WintabDN.dll&quot; &quot;C:\Program Files\paint.net\Effects\DynamicDraw&quot;&#xD;&#xA;move &quot;$(TargetDir)\DynamicDraw.deps.json&quot; &quot;C:\Program Files\paint.net\Effects\DynamicDraw&quot;&#xD;&#xA;&#xD;&#xA;&quot;C:\Program Files\paint.net\paintdotnet.exe&quot;" />
+    <Exec Command="if $(ConfigurationName)==FastDebug exit 0&#xD;&#xA;&#xD;&#xA;mkdir -p &quot;C:\Program Files\paint.net\Effects\DynamicDraw&quot;&#xD;&#xA;move &quot;$(TargetPath)&quot; &quot;C:\Program Files\paint.net\Effects\DynamicDraw&quot;&#xD;&#xA;move &quot;$(TargetDir)\WintabDN.dll&quot; &quot;C:\Program Files\paint.net\Effects\DynamicDraw&quot;&#xD;&#xA;move &quot;$(TargetDir)\DynamicDraw.deps.json&quot; &quot;C:\Program Files\paint.net\Effects\DynamicDraw&quot;&#xD;&#xA;&#xD;&#xA;&quot;C:\Program Files\paint.net\paintdotnet.exe&quot;" />
   </Target>
 </Project>

--- a/DynamicDraw.sln
+++ b/DynamicDraw.sln
@@ -13,11 +13,14 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		FastDebug|Any CPU = FastDebug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E5BEB701-F1C7-4DC1-9ECB-839237613E10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E5BEB701-F1C7-4DC1-9ECB-839237613E10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5BEB701-F1C7-4DC1-9ECB-839237613E10}.FastDebug|Any CPU.ActiveCfg = FastDebug|Any CPU
+		{E5BEB701-F1C7-4DC1-9ECB-839237613E10}.FastDebug|Any CPU.Build.0 = FastDebug|Any CPU
 		{E5BEB701-F1C7-4DC1-9ECB-839237613E10}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E5BEB701-F1C7-4DC1-9ECB-839237613E10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/FastDebug.cs
+++ b/FastDebug.cs
@@ -1,0 +1,26 @@
+﻿#if FASTDEBUG
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace DynamicDraw
+{
+    internal static class Program
+    {
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        private static void Main()
+        {
+            //Copies necessary user variables for dialog access.
+            UserSettings.userPrimaryColor = Color.Black;
+
+            Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new WinDynamicDraw());
+        }
+    }
+}
+#endif

--- a/Gui/DynamicDrawWindow.cs
+++ b/Gui/DynamicDrawWindow.cs
@@ -243,6 +243,8 @@ namespace DynamicDraw
         /// The starting index in the brush selector cache.
         /// </summary>
         private int visibleBrushImagesIndex;
+
+        private Surface srcSurface;
         #endregion
 
         #region Fields (Gui)
@@ -774,14 +776,21 @@ namespace DynamicDraw
         {
             base.OnLoad(e);
 
-            //Sets the sizes of the canvas and drawing region.
-            canvas.width = EnvironmentParameters.SourceSurface.Size.Width;
-            canvas.height = EnvironmentParameters.SourceSurface.Size.Height;
+#if FASTDEBUG
+            this.ShowInTaskbar = true;
+            srcSurface = new Surface(800, 600);
+#else
+            srcSurface = EnvironmentParameters.SourceSurface;
+#endif
 
-            bmpCurrentDrawing = Utils.CreateBitmapFromSurface(EnvironmentParameters.SourceSurface);
+            //Sets the sizes of the canvas and drawing region.
+            canvas.width = srcSurface.Width;
+            canvas.height = srcSurface.Height;
+
+            bmpCurrentDrawing = Utils.CreateBitmapFromSurface(srcSurface);
             symmetryOrigin = new PointF(
-                EnvironmentParameters.SourceSurface.Width / 2f,
-                EnvironmentParameters.SourceSurface.Height / 2f);
+                srcSurface.Width / 2f,
+                srcSurface.Height / 2f);
 
             //Sets the canvas dimensions.
             canvas.x = (displayCanvas.Width - canvas.width) / 2;
@@ -918,13 +927,16 @@ namespace DynamicDraw
 
             try
             {
+#if FASTDEBUG
+                string basePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "paint.net User Files");
+#else
                 IUserFilesService userFilesService =
                 (IUserFilesService)Services.GetService(typeof(IUserFilesService));
 
                 // userFilesService.UserFilesPath has been reported null before, so if it is, try to guess at the path.
                 string basePath = userFilesService.UserFilesPath ??
                     Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "paint.net User Files");
-
+#endif
                 string path = Path.Combine(basePath, "DynamicDrawSettings.xml");
                 settings = new DynamicDrawSettings(path);
 
@@ -1732,7 +1744,7 @@ namespace DynamicDraw
                                 if (activeTool == Tool.Eraser)
                                 {
                                     Utils.OverwriteMasked(
-                                        this.EnvironmentParameters.SourceSurface,
+                                        this.srcSurface,
                                         bmpCurrentDrawing,
                                         bmpBrushRotScaled,
                                         new Point(
@@ -1812,7 +1824,7 @@ namespace DynamicDraw
                                 if (activeTool == Tool.Eraser)
                                 {
                                     Utils.OverwriteMasked(
-                                        this.EnvironmentParameters.SourceSurface,
+                                        this.srcSurface,
                                         bmpCurrentDrawing,
                                         bmpBrushRotScaled,
                                         new Point(
@@ -1874,7 +1886,7 @@ namespace DynamicDraw
                                     if (activeTool == Tool.Eraser)
                                     {
                                         Utils.OverwriteMasked(
-                                            this.EnvironmentParameters.SourceSurface,
+                                            this.srcSurface,
                                             bmpCurrentDrawing,
                                             bmpBrushRotScaled,
                                             new Point(
@@ -1956,7 +1968,7 @@ namespace DynamicDraw
                                     if (activeTool == Tool.Eraser)
                                     {
                                         Utils.OverwriteMasked(
-                                        this.EnvironmentParameters.SourceSurface,
+                                        this.srcSurface,
                                         bmpCurrentDrawing,
                                         bmpBrushRotScaled,
                                         new Point(
@@ -5106,9 +5118,13 @@ namespace DynamicDraw
         /// </summary>
         private void DynamicDrawWindow_Load(object sender, EventArgs e)
         {
+#if FASTDEBUG
+            this.Size = new Size(1200, 900);
+#else
             this.DesktopLocation = Owner.PointToScreen(new Point(0, 30));
             this.Size = new Size(Owner.ClientSize.Width, Owner.ClientSize.Height - 30);
             this.WindowState = Owner.WindowState;
+#endif
         }
 
         /// <summary>
@@ -6274,8 +6290,8 @@ namespace DynamicDraw
             e.Graphics.SmoothingMode = SmoothingMode.None;
             e.Graphics.PixelOffsetMode = PixelOffsetMode.Half;
 
-            float drawingOffsetX = EnvironmentParameters.SourceSurface.Width * 0.5f * canvasZoom;
-            float drawingOffsetY = EnvironmentParameters.SourceSurface.Height * 0.5f * canvasZoom;
+            float drawingOffsetX = srcSurface.Width * 0.5f * canvasZoom;
+            float drawingOffsetY = srcSurface.Height * 0.5f * canvasZoom;
             
             e.Graphics.TranslateTransform(canvas.x + drawingOffsetX, canvas.y + drawingOffsetY);
             e.Graphics.RotateTransform(sliderCanvasAngle.Value);
@@ -6314,8 +6330,8 @@ namespace DynamicDraw
                         visibleBounds,
                         lCutoffUnzoomed,
                         tCutoffUnzoomed,
-                        EnvironmentParameters.SourceSurface.Width - overshootX / canvasZoom - lCutoffUnzoomed,
-                        EnvironmentParameters.SourceSurface.Height - overshootY / canvasZoom - tCutoffUnzoomed,
+                        srcSurface.Width - overshootX / canvasZoom - lCutoffUnzoomed,
+                        srcSurface.Height - overshootY / canvasZoom - tCutoffUnzoomed,
                         GraphicsUnit.Pixel);
                 }
                 else
@@ -6346,8 +6362,8 @@ namespace DynamicDraw
                     visibleBounds,
                     lCutoffUnzoomed,
                     tCutoffUnzoomed,
-                    EnvironmentParameters.SourceSurface.Width - overshootX / canvasZoom - lCutoffUnzoomed,
-                    EnvironmentParameters.SourceSurface.Height - overshootY / canvasZoom - tCutoffUnzoomed,
+                    srcSurface.Width - overshootX / canvasZoom - lCutoffUnzoomed,
+                    srcSurface.Height - overshootY / canvasZoom - tCutoffUnzoomed,
                     GraphicsUnit.Pixel);
             }
             else
@@ -6356,7 +6372,11 @@ namespace DynamicDraw
             }
 
             //Draws the selection.
+#if FASTDEBUG
+            var selection = new PdnRegion(srcSurface.Bounds);
+#else
             var selection = EnvironmentParameters.GetSelectionAsPdnRegion();
+#endif
             long area = selection.GetArea64();
 
             if (selection?.GetRegionReadOnly() != null)
@@ -6364,12 +6384,12 @@ namespace DynamicDraw
                 //Calculates the outline once the selection becomes valid.
                 if (selectionOutline == null)
                 {
-                    if (area != EnvironmentParameters.SourceSurface.Width * EnvironmentParameters.SourceSurface.Height)
+                    if (area != srcSurface.Width * srcSurface.Height)
                     {
                         selectionOutline = selection.ConstructOutline(
                             new RectangleF(0, 0,
-                            EnvironmentParameters.SourceSurface.Width,
-                            EnvironmentParameters.SourceSurface.Height),
+                            srcSurface.Width,
+                            srcSurface.Height),
                             canvasZoom);
                     }
                 }
@@ -6379,7 +6399,7 @@ namespace DynamicDraw
 
                 //Creates the inverted region of the selection.
                 var drawingArea = new Region(new Rectangle
-                    (0, 0, EnvironmentParameters.SourceSurface.Width, EnvironmentParameters.SourceSurface.Height));
+                    (0, 0, srcSurface.Width, srcSurface.Height));
                 drawingArea.Exclude(selection.GetRegionReadOnly());
 
                 //Draws the region as a darkening over unselected pixels.
@@ -6454,11 +6474,11 @@ namespace DynamicDraw
                         e.Graphics.DrawLine(
                             Pens.Red,
                             new PointF(0, symmetryOrigin.Y * canvasZoom),
-                            new PointF(EnvironmentParameters.SourceSurface.Width * canvasZoom, symmetryOrigin.Y * canvasZoom));
+                            new PointF(srcSurface.Width * canvasZoom, symmetryOrigin.Y * canvasZoom));
                         e.Graphics.DrawLine(
                             Pens.Red,
                             new PointF(symmetryOrigin.X * canvasZoom, 0),
-                            new PointF(symmetryOrigin.X * canvasZoom, EnvironmentParameters.SourceSurface.Height * canvasZoom));
+                            new PointF(symmetryOrigin.X * canvasZoom, srcSurface.Height * canvasZoom));
                     }
 
                     e.Graphics.ScaleTransform(canvasZoom, canvasZoom);
@@ -6506,8 +6526,8 @@ namespace DynamicDraw
                         }
                         else
                         {
-                            pointsDrawnX = (mouseLoc.X / canvasZoom - EnvironmentParameters.SourceSurface.Width / 2);
-                            pointsDrawnY = (mouseLoc.Y / canvasZoom - EnvironmentParameters.SourceSurface.Height / 2);
+                            pointsDrawnX = (mouseLoc.X / canvasZoom - srcSurface.Width / 2);
+                            pointsDrawnY = (mouseLoc.Y / canvasZoom - srcSurface.Height / 2);
 
                             for (int i = 0; i < symmetryOrigins.Count; i++)
                             {
@@ -6518,8 +6538,8 @@ namespace DynamicDraw
                                 angle -= sliderCanvasAngle.Value * Math.PI / 180;
                                 e.Graphics.DrawRectangle(
                                     Pens.Red,
-                                    (float)(EnvironmentParameters.SourceSurface.Width / 2 + dist * Math.Cos(angle) - 1),
-                                    (float)(EnvironmentParameters.SourceSurface.Height / 2 + dist * Math.Sin(angle) - 1),
+                                    (float)(srcSurface.Width / 2 + dist * Math.Cos(angle) - 1),
+                                    (float)(srcSurface.Height / 2 + dist * Math.Sin(angle) - 1),
                                     2, 2);
                             }
                         }
@@ -6530,11 +6550,11 @@ namespace DynamicDraw
                     e.Graphics.DrawLine(
                         Pens.Red,
                         new PointF(0, symmetryOrigin.Y * canvasZoom),
-                        new PointF(EnvironmentParameters.SourceSurface.Width * canvasZoom, symmetryOrigin.Y * canvasZoom));
+                        new PointF(srcSurface.Width * canvasZoom, symmetryOrigin.Y * canvasZoom));
                     e.Graphics.DrawLine(
                         Pens.Red,
                         new PointF(symmetryOrigin.X * canvasZoom, 0),
-                        new PointF(symmetryOrigin.X * canvasZoom, EnvironmentParameters.SourceSurface.Height * canvasZoom));
+                        new PointF(symmetryOrigin.X * canvasZoom, srcSurface.Height * canvasZoom));
                 }
             }
 


### PR DESCRIPTION
This configuration will build Dynamic Draw as an EXE, and you can debug it without having to start Paint.NET.

We've been using a similar "FastDebug" configuration in CodeLab for a few years now. It saves a ton of time.

![image](https://user-images.githubusercontent.com/11582193/150659924-9c9d579f-a0a3-46f9-8f94-df5530401e06.png)
